### PR TITLE
fix bone(s) quaternion not unit length after applying tpose

### DIFF
--- a/retargeting.js
+++ b/retargeting.js
@@ -802,7 +802,10 @@ function applyTPose(skeleton, map) {
     for(let i = 0; i < rightEnd.children.length; i++) {
         innerLoop(rightEnd.children[i]);
     }
-
+    //normalize bone quaternions
+    resultSkeleton.bones.forEach(bone =>{
+        bone.quaternion.normalize();
+    })
     // resultSkeleton.calculateInverses();
     resultSkeleton.update(); 
     return {skeleton: resultSkeleton, map};


### PR DESCRIPTION
Amazing library : )

This PR fixed issue with bone(s) quaternion not unit length after applying t-pose

[repro] retarget animation to model, export to gltf using GltfExporter and view here (https://gltf-viewer.donmccurdy.com/). Throws a bunch of errors that quaternion is not unit length